### PR TITLE
Refactor MTPManager class for improved security and usability

### DIFF
--- a/mtp.py
+++ b/mtp.py
@@ -43,19 +43,19 @@ class MTPManager:
         drive_letter: str,
         verbose: Optional[bool] = True,
     ):
-        self.mtpmount_path = Path(mtpmount_path)
-
-        if not self.mtpmount_path.is_file():
+        if not Path(mtpmount_path).is_file():
             raise FileNotFoundError(
-                f'Invalid mtpmount path: "{self.mtpmount_path}" does not exist.'
+                f'the mtpmount path "{mtpmount_path}" does not exist.'
             )
+        else:
+            self.mtpmount_path = Path(mtpmount_path)
+            self.process_name = self.mtpmount_path.name
 
-        self.process_name = self.mtpmount_path.name
         self.device_name = device_name
         self.storage_name = storage_name
 
         if not re.match(r"^[D-Zd-z]$", drive_letter):
-            raise ValueError(f'Invalid drive letter (D-Z): "{drive_letter}"')
+            raise ValueError(f'"{drive_letter}" is not a valid drive letter (D-Z).')
         else:
             self.drive_letter = drive_letter
 

--- a/mtp.py
+++ b/mtp.py
@@ -3,9 +3,11 @@
 # Date: 18-06-2023
 # Description: python access for mtpmount.
 
-
+import re
+import sys
 import subprocess
 from pathlib import Path
+from typing import Union, Optional, Any
 
 
 class MTPManager:
@@ -14,100 +16,127 @@ class MTPManager:
 
     Parameters
     ----------
-    mtpmount_path : str
+    mtpmount_path : Any
         The path to the mtpmount executable.
     device_name : str
         The name of the device to mount.
     storage_name : str
         The name of the storage to mount.
     drive_letter : str
-        The drive letter to mount the storage to.
-    verbose : bool, optional
+        A valid drive letter (D-Z) that is not already in use to mount the storage to.
+    verbose : bool, default=True
         Whether to print the output of subprocess commands.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `mtpmount_path` is not a valid file path.
+    ValueError
+        If `drive_letter` is not a valid drive letter (D-Z).
     """
 
     def __init__(
         self,
-        mtpmount_path: str,
+        mtpmount_path: Any,
         device_name: str,
         storage_name: str,
         drive_letter: str,
-        verbose: bool = True,
+        verbose: Optional[bool] = True,
     ):
         self.mtpmount_path = Path(mtpmount_path)
+
+        if not self.mtpmount_path.is_file():
+            raise FileNotFoundError(
+                f'Invalid mtpmount path: "{self.mtpmount_path}" does not exist.'
+            )
+
         self.process_name = self.mtpmount_path.name
         self.device_name = device_name
         self.storage_name = storage_name
-        self.drive_letter = drive_letter
+
+        if not re.match(r"^[D-Zd-z]$", drive_letter):
+            raise ValueError(f'Invalid drive letter (D-Z): "{drive_letter}"')
+        else:
+            self.drive_letter = drive_letter
+
         self.verbose = verbose
 
-    def copy_files(self, src, dest, overwrite=False) -> None:
+    def copy(
+        self, src: Union[Any, list[Any]], dest: Any, overwrite: Optional[bool] = False
+    ) -> None:
         """
         Copies one or more files / folders to the specified destination path.
 
         Parameters
         ----------
-        src
+        src : Any or list of Any
             A single path or a list of source paths to copy.
-        dest
+        dest : Any
             The destination path to copy to.
-        overwrite : bool, optional
+        overwrite : bool, default=False
             Overwrite existing files at the destination without prompting for confirmation.
 
         Raises
         ------
         ValueError
-            If `src_path` is not a valid file or folder path.
-
-            If the path is invalid, the user will be prompted to either skip the file/folder or cancel the operation.
-            If the user chooses to skip the file/folder, the operation will continue with the remaining files/folders.
-            If the user chooses to cancel the operation, the method will exit and no files/folders will be copied.
+            If `dest` does not match the drive letter of the MTP device.
+        ValueError
+            If `dest` is not a valid drive path format (e.g. X:/).
         """
+
+        if not dest.lower().startswith(self.drive_letter.lower()):
+            raise ValueError(
+                f'destination path does not match the drive letter of the MTP device ("{self.drive_letter}").'
+            )
+
+        if not re.match(r"^[A-Za-z]:/", dest):
+            raise ValueError("invalid drive path format (e.g. X:/)")
 
         # just in case the process is still running
         self.kill_process(self.process_name)
 
         self.manage_storage("mount")
-        overwrite_flag = "/Y" if overwrite else ""
+        overwrite_flag = "/Y"
+
+        if not isinstance(src, list):
+            src = [src]
 
         dest = Path(dest).resolve()
-        for src_path in src:
-            src_path = Path(src_path).resolve()
-            dest_item_path = dest / src_path.name
+        src = [Path(src_path).resolve() for src_path in src]
 
+        for src_path in src:
             try:
                 if src_path.is_file():
-                    cmd = f'xcopy "{src_path}" "{dest}" {overwrite_flag}'
-                    self.run_cmd(cmd, shell=True, check=True)
+                    cmd = ["xcopy", str(src_path), str(dest)]
+                    if overwrite:
+                        cmd.append(overwrite_flag)
+                    self.run_cmd(cmd, check=True)
 
                 elif src_path.is_dir():
-                    cmd = (
-                        f'xcopy "{src_path}" "{dest_item_path}" /E /I {overwrite_flag}'
-                    )
-                    self.run_cmd(cmd, shell=True, check=True)
+                    dest_dir_path = dest / src_path.name
+                    cmd = ["xcopy", str(src_path), str(dest_dir_path), "/E", "/I"]
+                    if overwrite:
+                        cmd.append(overwrite_flag)
+                    self.run_cmd(cmd, check=True)
 
                 else:
-                    raise ValueError(
-                        f'\nInvalid path: "{src_path}" is not a valid file or folder path. '
-                        "Please check the path and try again."
-                    )
+                    raise ValueError(f'the path "{src_path}" does not exist.')
 
+            # user can skip the current item or cancel the entire operation
             except ValueError as e:
                 while True:
                     response = input(
-                        f"{str(e)}\nDo you want to skip this file/folder,"
-                        "or cancel the operation? (Y/skip, N/cancel) "
+                        f"{e}\nDo you want to skip this item, or cancel the operation? Y (skip), N (cancel): "
                     )
                     if response.lower() in ["y", "n"]:
                         break
-                    else:
-                        print("Invalid response. Please enter either 'y' or 'n'.")
 
                 if response.lower() == "n":
                     break
                 else:
                     continue
 
+        # kill the process after unmount operation is complete
         unmount = self.manage_storage("unmount")
         if unmount.returncode == 0:
             self.kill_process(self.process_name)
@@ -119,65 +148,74 @@ class MTPManager:
         Parameters
         ----------
         operation : str
-            The operation to perform. Must be either "mount" or "unmount".
+            The operation to perform (mount or unmount).
 
         Returns
         -------
         subprocess.CompletedProcess
-            The return code of the operation, among other things.
-
-        Raises
-        ------
-        SystemExit
-            If the operation fails.
+            Used to check the return code of the mount operation.
         """
         try:
-            cmd = f'"{self.mtpmount_path}" {operation} "{self.device_name}" "{self.storage_name}" {self.drive_letter}'
-            mount_operation = self.run_cmd(cmd, shell=True, check=True)
+            cmd = [
+                str(self.mtpmount_path),
+                operation,
+                self.device_name,
+                self.storage_name,
+                self.drive_letter,
+            ]
+            mount_operation = self.run_cmd(cmd, check=True)
             return mount_operation
 
         except subprocess.CalledProcessError as e:
-            print(f"\n{e}")
+            if not self.verbose:
+                print(
+                    f"\nFailed to {operation} storage: {e}\n"
+                    "Check that the device is connected and the details are correct."
+                )
             self.kill_process(self.process_name)
-            raise SystemExit(1)
+            sys.exit(1)
 
-    def kill_process(self, process_name: str) -> None:
+    def kill_process(self, process_name) -> None:
         """
         Terminates the specified process if it is running.
 
         Parameters
         ----------
-        process_name : str
-            The name of the process to terminate.
+        process_name
+            The executable name of the process to terminate.
         """
 
         # Check if the process is running
-        cmd = f'tasklist /fi "imagename eq {process_name}"'
+        cmd = ["tasklist", "/fi", f"imagename eq {process_name}"]
         process_check = self.run_cmd(cmd, capture_output=True, text=True)
 
         # Check if the process name is found in the tasklist output
         if process_name.lower() in process_check.stdout.lower():
-            cmd = f"taskkill /f /im {process_name}"
-            self.run_cmd(cmd, shell=True, check=True)
+            cmd = ["taskkill", "/f", "/im", process_name]
+            self.run_cmd(cmd)
 
-    def run_cmd(self, cmd: str, **kwargs) -> subprocess.CompletedProcess:
+    def run_cmd(self, cmd, **kwargs) -> subprocess.CompletedProcess:
         """
         Executes the specified command.
 
         Parameters
         ----------
-        cmd : str
+        cmd
             The command to execute.
         **kwargs
-            Additional keyword arguments to pass to subprocess.run.
+            Keyword arguments to pass to `subprocess.run()`.
 
         Returns
         -------
         subprocess.CompletedProcess
-            The return code of the command, among other things.
+            Used to check the return code of the command.
         """
 
         if not self.verbose:
             kwargs.setdefault("capture_output", True)
+
+        # allow output even when verbose is False so user can interact with xcopy prompts
+        if "xcopy" in cmd and "/Y" not in cmd:
+            kwargs["capture_output"] = False
 
         return subprocess.run(cmd, **kwargs)


### PR DESCRIPTION
This PR adds several improvements to the MTPManager class in mtp.py. The changes include:

- Added a check to the `__init__` method to ensure the path to the mtpmount executable exists.
- Added a check in the `__init__` method to ensure the user enters a valid drive letter.
- Added a check in the `copy` method to ensure the destination path matches the drive letter.
- Switched from a string-based command with `shell=True` to a list of commands without `shell` for improved security (apparently).
- Added a condition in the `run_cmd` method that allows output from subprocess even when verbose is false to allow the user to see xcopy prompts in the terminal.
- Tidied up code in the `copy` method.
- Made several changes to comments, docstrings, and type hints.